### PR TITLE
US#33 & #34 - Added socket events for pause, resume and end game

### DIFF
--- a/Hunted Mobile/Hunted Mobile/Hunted Mobile/Service/WebSocketService.cs
+++ b/Hunted Mobile/Hunted Mobile/Hunted Mobile/Service/WebSocketService.cs
@@ -46,12 +46,18 @@ namespace Hunted_Mobile.Service {
 
         public delegate void SocketEvent();
         public event SocketEvent StartGame;
+        public event SocketEvent PauseGame;
+        public event SocketEvent ResumeGame;
+        public event SocketEvent EndGame;
 
         public WebSocketService(int gameId) {
             _pusher.SubscribeAsync("game." + gameId);
 
             string gameIdStr = gameId.ToString();
-            Bind("startGame", ()=> StartGame(), gameIdStr);
+            Bind("game.start", ()=> StartGame(), gameIdStr);
+            Bind("game.pause", ()=> PauseGame(), gameIdStr);
+            Bind("game.resume", ()=> ResumeGame(), gameIdStr);
+            Bind("game.end", ()=> EndGame(), gameIdStr);
         }
 
         private void Bind(string eventName, Action action, string gameIdStr) {

--- a/Hunted Mobile/Hunted Mobile/Hunted Mobile/ViewModel/MapViewModel.cs
+++ b/Hunted Mobile/Hunted Mobile/Hunted Mobile/ViewModel/MapViewModel.cs
@@ -67,11 +67,28 @@ namespace Hunted_Mobile.ViewModel {
             _gpsService.LocationChanged += MyLocationUpdated;
 
             #region Test code
+            // This if statement and its content can be safely deleted
             if(!WebSocketService.Connected) {
                 WebSocketService socket = new WebSocketService(1);
                 socket.Connect();
                 socket.StartGame += StartGame;
+                socket.ResumeGame += Socket_ResumeGame;
+                socket.PauseGame += Socket_PauseGame;
+                socket.EndGame += Socket_EndGame;
             }
+        }
+
+        // These methods can be safely deleted
+        private void Socket_EndGame() {
+            Console.WriteLine("Game end event received!");
+        }
+
+        private void Socket_PauseGame() {
+            Console.WriteLine("Game pause event received!");
+        }
+
+        private void Socket_ResumeGame() {
+            Console.WriteLine("Game resume event received!");
         }
 
         private void StartGame() {


### PR DESCRIPTION
Testen werkt hetzelfde als de vorige keer.
Zet breakpoints in het MapViewModel op: 
![image](https://user-images.githubusercontent.com/10811551/115111076-cd0fea00-9f7e-11eb-9363-33bf0f82c3cc.png)

Start de API op [deze branch](https://github.com/lderkzen/SOPROJ11Q/pull/15).
Open de app in het kaart scherm.
Ga in het configuratiescherm naar game 1 en druk op start spel, pauzeren, hervatten en beëindigen en kijk of de breakpoints geraakt worden.