### PR TITLE
US#419 - Kleur van het thema wordt weergegeven op navigatiebalk

### DIFF
--- a/Hunted Mobile/Hunted Mobile/Hunted Mobile.Android/MainActivity.cs
+++ b/Hunted Mobile/Hunted Mobile/Hunted Mobile.Android/MainActivity.cs
@@ -14,7 +14,7 @@ namespace Hunted_Mobile.Droid {
 
             Xamarin.Essentials.Platform.Init(this, savedInstanceState);
             global::Xamarin.Forms.Forms.Init(this, savedInstanceState);
-            LoadApplication(new App());
+            LoadApplication(new App(new ViewModel.AppViewModel()));
 
             CrossCurrentActivity.Current.Init(this, savedInstanceState);
         }

--- a/Hunted Mobile/Hunted Mobile/Hunted Mobile.iOS/AppDelegate.cs
+++ b/Hunted Mobile/Hunted Mobile/Hunted Mobile.iOS/AppDelegate.cs
@@ -21,7 +21,7 @@ namespace Hunted_Mobile.iOS {
         //
         public override bool FinishedLaunching(UIApplication app, NSDictionary options) {
             global::Xamarin.Forms.Forms.Init();
-            LoadApplication(new App());
+            LoadApplication(new App(new ViewModel.AppViewModel()));
 
             return base.FinishedLaunching(app, options);
         }

--- a/Hunted Mobile/Hunted Mobile/Hunted Mobile/View/App.xaml
+++ b/Hunted Mobile/Hunted Mobile/Hunted Mobile/View/App.xaml
@@ -3,6 +3,9 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="Hunted_Mobile.App">
     <Application.Resources>
-
+        <Style TargetType="NavigationPage">
+            <Setter Property="BarBackgroundColor" Value="{Binding ColourTheme}"></Setter>
+            <Setter Property="BarTextColor" Value="White"></Setter>
+        </Style>
     </Application.Resources>
 </Application>

--- a/Hunted Mobile/Hunted Mobile/Hunted Mobile/View/App.xaml.cs
+++ b/Hunted Mobile/Hunted Mobile/Hunted Mobile/View/App.xaml.cs
@@ -1,13 +1,16 @@
 ﻿using Hunted_Mobile.View;
+using Hunted_Mobile.ViewModel;
 
 using Xamarin.Forms;
 
 namespace Hunted_Mobile {
     public partial class App : Application {
-        public App() {
+        public App(AppViewModel viewModel) {
             InitializeComponent();
 
-            MainPage = new NavigationPage(new MainPage());
+            BindingContext = viewModel;
+
+            MainPage = new NavigationPage(new MainPage(viewModel));
         }
 
         protected override void OnStart() {

--- a/Hunted Mobile/Hunted Mobile/Hunted Mobile/View/MainPage.xaml.cs
+++ b/Hunted Mobile/Hunted Mobile/Hunted Mobile/View/MainPage.xaml.cs
@@ -5,9 +5,9 @@ using Hunted_Mobile.ViewModel;
 namespace Hunted_Mobile.View {
     public partial class MainPage : ContentPage {
         private readonly MainPageViewModel mainPageViewModel;
-        public MainPage() {
+        public MainPage(AppViewModel appViewModel) {
             this.InitializeComponent();
-            BindingContext = mainPageViewModel = new MainPageViewModel(this);
+            BindingContext = mainPageViewModel = new MainPageViewModel(this, appViewModel);
         }
 
         // This method is called when rendering this page, because the InviteKey should be reset

--- a/Hunted Mobile/Hunted Mobile/Hunted Mobile/ViewModel/AppViewModel.cs
+++ b/Hunted Mobile/Hunted Mobile/Hunted Mobile/ViewModel/AppViewModel.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Hunted_Mobile.ViewModel {
+    public class AppViewModel : BaseViewModel {
+        private string colourTheme;
+
+        public string ColourTheme {
+            get => colourTheme;
+            set {
+                colourTheme = value;
+                OnPropertyChanged(nameof(ColourTheme));
+            }
+        }
+
+        public AppViewModel() {
+            ResetColor();
+        }
+
+        public void ResetColor() {
+            ColourTheme = null;
+        }
+    }
+}

--- a/Hunted Mobile/Hunted Mobile/Hunted Mobile/ViewModel/EnterUsernameViewModel.cs
+++ b/Hunted Mobile/Hunted Mobile/Hunted Mobile/ViewModel/EnterUsernameViewModel.cs
@@ -17,6 +17,7 @@ namespace Hunted_Mobile.ViewModel {
         private Player userModel;
         private bool isloading = false;
         private EnterUsername page;
+        private readonly AppViewModel appViewModel;
 
         public bool IsValid { get; set; }
 
@@ -38,8 +39,9 @@ namespace Hunted_Mobile.ViewModel {
 
         public EnterUsername View { set => page = value; }
 
-        public EnterUsernameViewModel(InviteKey key) {
+        public EnterUsernameViewModel(InviteKey key, AppViewModel appViewModel) {
             userModel = new PlayerBuilder().SetInviteKey(key).ToPlayer();
+            this.appViewModel = appViewModel;
         }
 
         /// <summary>
@@ -64,7 +66,7 @@ namespace Hunted_Mobile.ViewModel {
                 var navigation = Application.Current.MainPage.Navigation;
 
                 var previousPage = navigation.NavigationStack.LastOrDefault();
-                var view = new Lobby(new LobbyViewModel(UserModel));
+                var view = new Lobby(new LobbyViewModel(UserModel, appViewModel));
                 await navigation.PushAsync(view, true);
                 navigation.RemovePage(previousPage);
             }

--- a/Hunted Mobile/Hunted Mobile/Hunted Mobile/ViewModel/LobbyViewModel.cs
+++ b/Hunted Mobile/Hunted Mobile/Hunted Mobile/ViewModel/LobbyViewModel.cs
@@ -21,11 +21,13 @@ namespace Hunted_Mobile.ViewModel {
         private readonly WebSocketService webSocketService;
         private readonly GameSessionPreference gameSessionPreference;
         private bool isloading;
+        private readonly AppViewModel appViewModel;
 
         public Game GameModel {
             get => gameModel;
             set {
                 gameModel = value;
+                appViewModel.ColourTheme = gameModel.ColourTheme;
                 OnPropertyChanged("GameModel");
             }
         }
@@ -55,7 +57,8 @@ namespace Hunted_Mobile.ViewModel {
             get => new ObservableCollection<Player>(Users.Where(user => user is Police).ToList());
         }
 
-        public LobbyViewModel(Player currentUser) {
+        public LobbyViewModel(Player currentUser, AppViewModel appViewModel) {
+            this.appViewModel = appViewModel;
             this.currentUser = currentUser;
             gameModel.Id = this.currentUser.InviteKey.GameId;
             gameSessionPreference = new GameSessionPreference();
@@ -123,7 +126,7 @@ namespace Hunted_Mobile.ViewModel {
                     PlayingUser = currentUser
                 };
 
-                var mapPage = new MapPage(new MapViewModel(GameModel, mapModel));
+                var mapPage = new MapPage(new MapViewModel(GameModel, mapModel, appViewModel));
 
                 Device.BeginInvokeOnMainThread(() => {
                     webSocketService.StartGame -= StartGame;

--- a/Hunted Mobile/Hunted Mobile/Hunted Mobile/ViewModel/MainPageViewModel.cs
+++ b/Hunted Mobile/Hunted Mobile/Hunted Mobile/ViewModel/MainPageViewModel.cs
@@ -20,6 +20,7 @@ namespace Hunted_Mobile.ViewModel {
         private bool isloading;
         private ObservableCollection<InviteKey> inviteKeys = new ObservableCollection<InviteKey>();
         private readonly MainPage page;
+        private readonly AppViewModel appViewModel;
         private Game gameModel;
         private Player playingUser;
         private bool isOverlayVisible;
@@ -74,8 +75,9 @@ namespace Hunted_Mobile.ViewModel {
         public bool IsValid { get; set; }
         public InviteKey SelectedPreferenceGame { get; set; }
 
-        public MainPageViewModel(MainPage page) {
+        public MainPageViewModel(MainPage page, AppViewModel appViewModel) {
             this.page = page;
+            this.appViewModel = appViewModel;
             gameSessionPreference = new GameSessionPreference();
             AskPermission();
         }
@@ -134,7 +136,7 @@ namespace Hunted_Mobile.ViewModel {
         });
 
         public async Task NavigateToEnterUsernamePage() {
-            var viewModel = new EnterUsernameViewModel(inviteKeyModel);
+            var viewModel = new EnterUsernameViewModel(inviteKeyModel, appViewModel);
             var view = new EnterUsername(viewModel);
             await Xamarin.Forms.Application.Current.MainPage.Navigation.PushAsync(view);
         }
@@ -220,7 +222,7 @@ namespace Hunted_Mobile.ViewModel {
         private async Task NavigateToLobbyPage() {
             if(!PermissionService.HasGpsPermission) return;
 
-            await Xamarin.Forms.Application.Current.MainPage.Navigation.PushAsync(new Lobby(new LobbyViewModel(playingUser)), true);
+            await Xamarin.Forms.Application.Current.MainPage.Navigation.PushAsync(new Lobby(new LobbyViewModel(playingUser, appViewModel)), true);
         }
 
         private async Task NavigateToMapPage() {
@@ -229,7 +231,7 @@ namespace Hunted_Mobile.ViewModel {
                     PlayingUser = playingUser,
                 };
 
-                var mapPage = new MapPage(new MapViewModel(gameModel, mapModel));
+                var mapPage = new MapPage(new MapViewModel(gameModel, mapModel, appViewModel));
                 await Xamarin.Forms.Application.Current.MainPage.Navigation.PushAsync(mapPage, true);
             }
             catch(Exception ex) {

--- a/Hunted Mobile/Hunted Mobile/Hunted Mobile/ViewModel/MapViewModel.cs
+++ b/Hunted Mobile/Hunted Mobile/Hunted Mobile/ViewModel/MapViewModel.cs
@@ -97,9 +97,12 @@ namespace Hunted_Mobile.ViewModel {
             get => gameModel;
             set {
                 gameModel = value;
+                appViewModel.ColourTheme = gameModel.ColourTheme;
                 OnPropertyChanged("GameModel");
             }
         }
+
+        private readonly AppViewModel appViewModel;
 
         public bool OpenMainMapMenu {
             get => openMainMapMenu;
@@ -163,9 +166,10 @@ namespace Hunted_Mobile.ViewModel {
         public bool DroneActive { get; private set; }
         #endregion
 
-        public MapViewModel(Game gameModel, Model.Map mapModel) {
+        public MapViewModel(Game gameModel, Model.Map mapModel, AppViewModel appViewModel) {
             this.mapModel = mapModel;
-            this.gameModel = gameModel;
+            this.appViewModel = appViewModel;
+            GameModel = gameModel;
             var gameIdStr = gameModel.Id.ToString();
             messageViewModel = new MessageViewModel(gameIdStr, gameModel.ColourTheme);
             messagesView = new View.Messages(messageViewModel);
@@ -844,7 +848,8 @@ namespace Hunted_Mobile.ViewModel {
 
         private async void ExitGame() {
             GameSessionPreference.ClearUserAndGame();
-            await Xamarin.Forms.Application.Current.MainPage.Navigation.PushAsync(new MainPage());
+            appViewModel.ResetColor();
+            await Xamarin.Forms.Application.Current.MainPage.Navigation.PushAsync(new MainPage(appViewModel));
             RemovePreviousNavigation();
             await webSocketService.Disconnect();
         }

--- a/Hunted Mobile/Hunted Mobile/Hunted Mobile/ViewModel/MessageViewModel.cs
+++ b/Hunted Mobile/Hunted Mobile/Hunted Mobile/ViewModel/MessageViewModel.cs
@@ -17,7 +17,7 @@ namespace Hunted_Mobile.ViewModel {
         public string ColourTheme {
             get => colourTheme; set {
                 colourTheme = value;
-                OnPropertyChanged(ColourTheme);
+                OnPropertyChanged(nameof(ColourTheme));
             }
         }
 


### PR DESCRIPTION
Let niet op de icoontjes, die zijn van de oude API versie. Let ook niet op het feit dat de plaatjes enorm zijn lol.

Op hoofdscherm (standaardkleur):
![image](https://cdn.discordapp.com/attachments/448568485862178826/854398144477528104/Screenshot_20210615-183048.png)

In map (en lobby) (thema kleur):
![image](https://cdn.discordapp.com/attachments/448568485862178826/854397926252347393/Screenshot_20210615-183122.png)